### PR TITLE
Simplify Error definition with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "reqwest",
  "scraper",
  "tar",
+ "thiserror",
  "tokio",
  "url",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ octocrab = "0.43.0"
 reqwest = { version = "0.12.12", features = ["blocking"] }
 scraper = "0.22.0"
 tar = "0.4.43"
+thiserror = "2.0.11"
 tokio = "1.43.0"
 url = "2.5.4"
 zstd = "0.13.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,64 +1,25 @@
-#[derive(Debug)]
+use thiserror::Error;
+
+#[derive(Debug, Error)]
 pub enum Error {
-    Request(reqwest::Error),
-    Octocrab(octocrab::Error),
+    #[error(transparent)]
+    Request(#[from] reqwest::Error),
+    #[error(transparent)]
+    Octocrab(#[from] octocrab::Error),
+    #[error("{0}")]
     Scraper(String),
-    Url(url::ParseError),
-    Fs(std::io::Error),
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+    #[error(transparent)]
+    Fs(#[from] std::io::Error),
+    #[error("Could not find {0} to download.")]
     VersionNotFound(String),
+    #[error("{0} is not a valid Python version")]
     InvalidVersion(String),
+    #[error("Could not parse version and release_tag from {0}.")]
     ParseAsset(String),
+    #[error("{0} is not supported.")]
     Platform(String),
-    EnvVar(std::env::VarError),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Request(err) => write!(f, "{err}"),
-            Self::Octocrab(err) => write!(f, "{err}"),
-            Self::Fs(err) => write!(f, "{err}"),
-            Self::Url(err) => write!(f, "{err}"),
-            Self::VersionNotFound(version) => write!(f, "Could not find {version} to download."),
-            Self::InvalidVersion(version) => write!(f, "{version} is not a valid Python version"),
-            Self::ParseAsset(asset) => {
-                write!(f, "Could not parse version and release_tag from {asset}.")
-            }
-            Self::Scraper(error) => write!(f, "{error}"),
-            Self::Platform(platform) => write!(f, "{platform} is not supported."),
-            Self::EnvVar(error) => write!(f, "{error}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
-
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
-        Self::Request(err)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Self::Fs(err)
-    }
-}
-
-impl From<octocrab::Error> for Error {
-    fn from(err: octocrab::Error) -> Self {
-        Self::Octocrab(err)
-    }
-}
-
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Self {
-        Self::Url(err)
-    }
-}
-
-impl From<std::env::VarError> for Error {
-    fn from(err: std::env::VarError) -> Self {
-        Self::EnvVar(err)
-    }
+    #[error(transparent)]
+    EnvVar(#[from] std::env::VarError),
 }


### PR DESCRIPTION
Using `thiserror` reduces the amount of boilerplate code needed for the `Error` enum.