### PR TITLE
Allow omitting version in lilyenv activate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,8 @@ pub enum Error {
     Platform(String),
     #[error(transparent)]
     EnvVar(#[from] std::env::VarError),
+    #[error("Cannot activate {0}, no virtualenvs available, choose a version to download")]
+    NoVersions(String),
+    #[error("Cannot activate {0}, you must choose a version:\n{1}")]
+    MultipleVersions(String, String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use crate::error::Error;
 use crate::shell::{print_shell_config, set_shell};
 use crate::version::Version;
 use crate::virtualenvs::{
-    activate_virtualenv, cd_site_packages, create_virtualenv, print_all_versions,
+    activate_virtualenv, cd_site_packages, create_virtualenv, get_version, print_all_versions,
     print_project_versions, remove_project, remove_virtualenv, set_project_directory,
     unset_project_directory,
 };
@@ -29,7 +29,7 @@ enum Commands {
     /// Activate a virtualenv given a Project string and a Python version
     Activate {
         project: String,
-        version: Version,
+        version: Option<Version>,
         #[arg(long)]
         no_cd: bool,
         #[arg(short, long, default_value=None, default_missing_value=".", num_args=0..=1)]
@@ -100,6 +100,10 @@ fn run() -> Result<(), Error> {
             no_cd,
             directory,
         } => {
+            let version = match version {
+                Some(version) => version,
+                None => get_version(&project)?,
+            };
             activate_virtualenv(&version, &project, no_cd, directory)?;
         }
         Commands::SetShell { shell, project } => set_shell(&shell, project.as_deref())?,

--- a/src/virtualenvs.rs
+++ b/src/virtualenvs.rs
@@ -186,3 +186,17 @@ pub fn print_all_versions() -> Result<(), Error> {
     }
     Ok(())
 }
+
+pub fn get_version(project: &str) -> Result<Version, Error> {
+    let virtualenvs = project_dir(&project);
+    let versions =
+        list_versions(virtualenvs).map_err(|_| Error::NoVersions(project.to_string()))?;
+    match versions.len() {
+        1 => versions[0].parse::<Version>(),
+        0 => Err(Error::NoVersions(project.to_string())),
+        _ => Err(Error::MultipleVersions(
+            project.to_string(),
+            versions.join(" "),
+        )),
+    }
+}


### PR DESCRIPTION
If there is only one virtualenv for the project, activate it. Otherwise emit an error message to guide the user.

Fixes #12.