### PR TITLE
Improve error messages for GitHub API failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1056,6 +1056,7 @@ dependencies = [
  "current_platform",
  "directories",
  "flate2",
+ "http",
  "nom",
  "octocrab",
  "reqwest",
@@ -1231,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.43.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27527d68322f4c603319f7958973db8f9fa4be62c0e3fafe084f5562cf6353df"
+checksum = "86996964f8b721067b6ed238aa0ccee56ecad6ee5e714468aa567992d05d2b91"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ clap = { version = "4.5.26", features = ["derive"] }
 current_platform = "0.2.0"
 directories = "6.0.0"
 flate2 = "1.0.35"
+http = "1.3.1"
 nom = "7.1.3"
-octocrab = "0.43.0"
+octocrab = "0.44.1"
 reqwest = { version = "0.12.12", features = ["blocking"] }
 scraper = "0.22.0"
 tar = "0.4.43"

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,4 +26,8 @@ pub enum Error {
     NoVersions(String),
     #[error("Cannot activate {0}, you must choose a version:\n{1}")]
     MultipleVersions(String, String),
+    #[error("Failed to get CPython download information from GitHub API.")]
+    CPythonDownloadError,
+    #[error("Failed to get CPython download information from GitHub API due to rate limiting.")]
+    CPythonDownloadRateLimit,
 }


### PR DESCRIPTION
We've been seeing two particular errors:

* 504 Gateway Timeout (manifesting as a serde error)
* 403/429 Rate Limiting

This implements retry logic for server errors and serde errors. If the retries don't fix the problem, return a `CPythonDownloadError`.

This also returns a `CPythonDownloadRateLimit` error with a better error message when the client is rate limited.

Fixes #13.