### PR TITLE
Improve CPython release sorting and drop duplicates

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -21,8 +21,7 @@ pub fn print_available_downloads() -> Result<(), Error> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    let mut releases = rt.block_on(cpython_releases())?;
-    releases.sort_unstable_by_key(|p| p.version);
+    let releases = rt.block_on(cpython_releases())?;
     for python in releases {
         println!("{} ({})", python.version, python.release_tag);
     }


### PR DESCRIPTION
Sometimes there are multiple `release_tag`s for the same CPython version, so drop all but the newest. Also only include "install only", debug and freethreaded releases. Ignore other full archive releases.